### PR TITLE
Panel not function if install composer with --no-dev

### DIFF
--- a/src/Panel.php
+++ b/src/Panel.php
@@ -60,7 +60,10 @@ class Panel implements Tracy\IBarPanel
 		$installed = $this->decode($lockFile);
 
 		if ($this->error === NULL) {
+			$required = array_filter($required);
+			$installed = array_filter($installed);
 			$required += ['require' => [], 'require-dev' => []];
+			$installed += ['packages' => [], 'packages-dev' => []];
 			$data = [
 				'Packages' => self::format($installed['packages'], $required['require']),
 				'Dev Packages' => self::format($installed['packages-dev'], $required['require-dev']),


### PR DESCRIPTION
If you install composer with --no-dev $installed['require-dev'] is NULL but array is required in method format()
