### PR TITLE
Removed fixed width

### DIFF
--- a/src/templates/Panel.panel.phtml
+++ b/src/templates/Panel.panel.phtml
@@ -22,10 +22,6 @@ use Tracy\Helpers;
 		font-size: 85% !important;
 	}
 
-	.milo-VendorVersionsPanel .tracy-inner {
-		width: 500px;
-	}
-
 	.milo-VendorVersionsPanel table {
 		white-space: nowrap;
 		font: 9pt/1.5 Consolas,monospace !important;


### PR DESCRIPTION
No reason to have fixed width. Max width 700px from Tracy defaults is enough. For shorter packages names it creates big whitespace at right side.